### PR TITLE
Make entry headings larger and more prominent

### DIFF
--- a/lexdb-ui.el
+++ b/lexdb-ui.el
@@ -276,8 +276,8 @@ Returns alist of (adapter-id . (entries . adapter))."
 
 ;; Headword and pronunciation
 (defface lexdb-headword-face
-  '((((background dark))  :foreground "#04cecd" :weight bold)
-    (((background light)) :foreground "#fe0000" :weight bold))
+  '((((background dark))  :foreground "#04cecd" :weight bold :height 1.3)
+    (((background light)) :foreground "#fe0000" :weight bold :height 1.3))
   "Face for headword display."
   :group 'lexdb)
 


### PR DESCRIPTION
Add :height 1.3 to lexdb-headword-face to make entry headings (like "CALL" and "call¹") visually larger than the default font, improving readability and visual hierarchy.