### PR TITLE
fix: 修复 idiom 无英文定义时显示空行问题

### DIFF
--- a/lexdb-ui.el
+++ b/lexdb-ui.el
@@ -2409,51 +2409,57 @@ PHRASAL-VERBS is a list or vector of alists with headword, pos, and senses."
               (when idiom-text
                 (insert (propertize idiom-text 'face '(:inherit lexdb-phrase-face :weight bold))))
               (insert "\n")
-              ;; Second line: labels and definition
-              (insert "  ")
-              ;; Labels (fml, infml, etc.) before definition
-              (let ((idiom-labels (alist-get 'labels idiom)))
-                (when idiom-labels
-                  (let ((label-list (cond ((vectorp idiom-labels) (append idiom-labels nil))
-                                          ((listp idiom-labels) idiom-labels)
-                                          (t nil))))
-                    (dolist (label label-list)
-                      (let ((lvalue (alist-get 'value label)))
-                        (when lvalue
-                          (insert (propertize lvalue 'face 'lexdb-grammar-face) " ")))))))
-              ;; Definition - check for pre-parsed crossref first, then fallback to regex
-              (when (and idiom-def (stringp idiom-def) (not (string-empty-p idiom-def)))
-                (let ((crossref (alist-get 'crossref idiom)))
-                  (if crossref
-                      ;; Pre-parsed crossref from database (new format)
-                      (let* ((prefix (alist-get 'prefix crossref))
-                             (clickable (alist-get 'clickable crossref))
-                             (target-word (alist-get 'target_word crossref))
-                             (search-word (lexdb-ui--normalize-search-word
-                                           (or target-word clickable))))
-                        (when prefix
-                          (insert (propertize prefix 'face 'lexdb-crossref-face)))
-                        (insert-text-button clickable
-                                            'face 'lexdb-crossref-face
-                                            'action (lambda (_)
-                                                      (lexdb-search-and-goto-sense
-                                                       search-word nil jump-adapter))
-                                            'help-echo (format "Look up: %s [%s]"
-                                                               search-word jump-adapter)))
-                    ;; Fallback: regex detection for legacy data (→word.)
-                    (if (string-match "^→\\([^.]+\\)\\.$" idiom-def)
-                        (let* ((raw-target (match-string 1 idiom-def))
-                               (search-word (lexdb-ui--normalize-search-word raw-target)))
-                          (insert (propertize "→" 'face 'lexdb-crossref-face))
-                          (insert-text-button raw-target
-                                              'face 'lexdb-crossref-face
-                                              'action (lambda (_)
-                                                        (lexdb-search-and-goto-sense
-                                                         search-word nil jump-adapter))
-                                              'help-echo (format "Look up: %s [%s]" search-word jump-adapter)))
-                      ;; Regular definition with format markers
-                      (lexdb-ui--insert-formatted-definition idiom-def 'lexdb-definition-face)))))
-              (insert "\n")
+              ;; Second line: labels and definition (only if there's content)
+              (let* ((idiom-labels (alist-get 'labels idiom))
+                     (label-list (cond ((vectorp idiom-labels) (append idiom-labels nil))
+                                       ((listp idiom-labels) idiom-labels)
+                                       (t nil)))
+                     (has-valid-labels (and label-list
+                                            (cl-some (lambda (l) (alist-get 'value l)) label-list)))
+                     ;; Only show definition if it contains English letters
+                     (idiom-def-valid (and idiom-def (stringp idiom-def)
+                                           (not (string-empty-p idiom-def))
+                                           (string-match-p "[a-zA-Z]" idiom-def))))
+                (when (or has-valid-labels idiom-def-valid)
+                  (insert "  ")
+                  ;; Labels (fml, infml, etc.) before definition
+                  (dolist (label label-list)
+                    (let ((lvalue (alist-get 'value label)))
+                      (when lvalue
+                        (insert (propertize lvalue 'face 'lexdb-grammar-face) " "))))
+                  ;; Definition - check for pre-parsed crossref first, then fallback to regex
+                  (when idiom-def-valid
+                    (let ((crossref (alist-get 'crossref idiom)))
+                      (if crossref
+                          ;; Pre-parsed crossref from database (new format)
+                          (let* ((prefix (alist-get 'prefix crossref))
+                                 (clickable (alist-get 'clickable crossref))
+                                 (target-word (alist-get 'target_word crossref))
+                                 (search-word (lexdb-ui--normalize-search-word
+                                               (or target-word clickable))))
+                            (when prefix
+                              (insert (propertize prefix 'face 'lexdb-crossref-face)))
+                            (insert-text-button clickable
+                                                'face 'lexdb-crossref-face
+                                                'action (lambda (_)
+                                                          (lexdb-search-and-goto-sense
+                                                           search-word nil jump-adapter))
+                                                'help-echo (format "Look up: %s [%s]"
+                                                                   search-word jump-adapter)))
+                        ;; Fallback: regex detection for legacy data (→word.)
+                        (if (string-match "^→\\([^.]+\\)\\.$" idiom-def)
+                            (let* ((raw-target (match-string 1 idiom-def))
+                                   (search-word (lexdb-ui--normalize-search-word raw-target)))
+                              (insert (propertize "→" 'face 'lexdb-crossref-face))
+                              (insert-text-button raw-target
+                                                  'face 'lexdb-crossref-face
+                                                  'action (lambda (_)
+                                                            (lexdb-search-and-goto-sense
+                                                             search-word nil jump-adapter))
+                                                  'help-echo (format "Look up: %s [%s]" search-word jump-adapter)))
+                          ;; Regular definition with format markers
+                          (lexdb-ui--insert-formatted-definition idiom-def 'lexdb-definition-face)))))
+                  (insert "\n")))
               (when idiom-examples
                 (let ((ex-list (cond ((vectorp idiom-examples) (append idiom-examples nil))
                                      ((listp idiom-examples) idiom-examples)

--- a/lexdb-ui.el
+++ b/lexdb-ui.el
@@ -2405,12 +2405,24 @@ PHRASAL-VERBS is a list or vector of alists with headword, pos, and senses."
                                       'help-echo "Press t to peek translation")
                           " ")
                 (insert "  "))
-              ;; Idiom text
+              ;; Idiom text (bold)
               (when idiom-text
-                (insert (propertize idiom-text 'face 'lexdb-phrase-face)))
+                (insert (propertize idiom-text 'face '(:inherit lexdb-phrase-face :weight bold))))
+              (insert "\n")
+              ;; Second line: labels and definition
+              (insert "  ")
+              ;; Labels (fml, infml, etc.) before definition
+              (let ((idiom-labels (alist-get 'labels idiom)))
+                (when idiom-labels
+                  (let ((label-list (cond ((vectorp idiom-labels) (append idiom-labels nil))
+                                          ((listp idiom-labels) idiom-labels)
+                                          (t nil))))
+                    (dolist (label label-list)
+                      (let ((lvalue (alist-get 'value label)))
+                        (when lvalue
+                          (insert (propertize lvalue 'face 'lexdb-grammar-face) " ")))))))
               ;; Definition - check for pre-parsed crossref first, then fallback to regex
               (when (and idiom-def (stringp idiom-def) (not (string-empty-p idiom-def)))
-                (insert " ")
                 (let ((crossref (alist-get 'crossref idiom)))
                   (if crossref
                       ;; Pre-parsed crossref from database (new format)
@@ -2439,8 +2451,8 @@ PHRASAL-VERBS is a list or vector of alists with headword, pos, and senses."
                                                         (lexdb-search-and-goto-sense
                                                          search-word nil jump-adapter))
                                               'help-echo (format "Look up: %s [%s]" search-word jump-adapter)))
-                      ;; Regular definition
-                      (insert (propertize idiom-def 'face 'lexdb-definition-face))))))
+                      ;; Regular definition with format markers
+                      (lexdb-ui--insert-formatted-definition idiom-def 'lexdb-definition-face)))))
               (insert "\n")
               (when idiom-examples
                 (let ((ex-list (cond ((vectorp idiom-examples) (append idiom-examples nil))

--- a/scripts/mdx2db_oald.py
+++ b/scripts/mdx2db_oald.py
@@ -706,6 +706,7 @@ def parse_oald4_idiom(idiom_div):
         'text': '',
         'definition': '',
         'definition_zh': '',
+        'labels': [],  # Register labels like fml, infml
         'examples': []
     }
 
@@ -717,6 +718,12 @@ def parse_oald4_idiom(idiom_div):
     # Find sense (se or se3)
     se = idiom_div.find('div', class_=['se', 'se3'])
     if se:
+        # Extract register labels (fml, infml, etc.) - they are outside df
+        for reg in se.find_all('span', class_='reg', recursive=False):
+            reg_text = clean_text(reg.get_text())
+            if reg_text:
+                idiom['labels'].append({'type': 'register', 'value': reg_text})
+
         # First try df element
         df = se.find(['span', 'div'], class_='df')
         if df:


### PR DESCRIPTION
- 当 idiom 的 definition 字段不包含英文字母时（如 MDX 解析错误导致只有 :），跳过渲染第二行
- 避免 "the day after tomorrow" 等 idiom 显示多余空行