### PR TITLE
fix: LDOCE parsing improvements and UI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.DS_Store
+__pycache__/

--- a/lexdb-ui.el
+++ b/lexdb-ui.el
@@ -40,12 +40,13 @@
     (idioms          . lexdb-ui--slot-idioms)
     (phrasal-verbs   . lexdb-ui--slot-phrasal-verbs)
     (synonyms        . lexdb-ui--slot-synonyms)
+    (runons          . lexdb-ui--slot-runons)
     (separator       . lexdb-ui--slot-separator))
   "Alist mapping slot names to rendering functions.
 Each function takes (entry adapter) and renders content at point.")
 
 (defcustom lexdb-ui-default-template
-  '(header tabs senses entry-grammar-box idioms phrasal-verbs synonyms separator)
+  '(header tabs senses entry-grammar-box idioms phrasal-verbs synonyms runons separator)
   "Default slot order for rendering entries.
 This is a list of slot names from `lexdb-ui-slot-functions'."
   :type '(repeat symbol)
@@ -1175,14 +1176,10 @@ Optional ENTRY provides access to entry-level metadata for lexunits/grambox."
                                 gps))))
             (when codes
               (insert (propertize (string-join codes " ") 'face 'lexdb-grammar-face) " "))))))
-    ;; Grammar label (for non-OALD adapters)
-    (when (memq 'grammar caps)
-      (when-let ((gram (lexdb-sense-grammar sense)))
-        (when (lexdb--non-empty-string-p gram)
-          (insert (propertize gram 'face 'lexdb-grammar-face) " "))))
-    ;; Lexunit prefix (e.g., "all round British English, all around American English")
+    ;; Lexunit prefix (e.g., "particulars", "all round British English")
     ;; Read from entry-level sense_lexunit_prefixes indexed by sense number
     ;; Now structured: [{'type': 'lexunit'/'geo'/'lexvar', 'text': '...'}, ...]
+    ;; Rendered BEFORE grammar label so "particulars [plural]" not "[plural] particulars"
     (when entry
       (let* ((sense-prefixes (lexdb-meta-get (lexdb-entry-metadata entry) ns "sense_lexunit_prefixes"))
              (lexunit-prefix (when sense-prefixes
@@ -1214,6 +1211,11 @@ Optional ENTRY provides access to entry-level metadata for lexunits/grambox."
                     (insert (propertize ptext 'face 'lexdb-lexunit-face))))
                   (setq first-part nil))))
             (when parts (insert " "))))))
+    ;; Grammar label (for non-OALD adapters) - after lexunit prefix
+    (when (memq 'grammar caps)
+      (when-let ((gram (lexdb-sense-grammar sense)))
+        (when (lexdb--non-empty-string-p gram)
+          (insert (propertize gram 'face 'lexdb-grammar-face) " "))))
     ;; Register labels (e.g., "formal", "informal") - after lexunit, before definition
     ;; Also geographic/regional labels (e.g., "especially British English")
     (let ((labels (lexdb-sense-labels sense)))
@@ -2409,51 +2411,57 @@ PHRASAL-VERBS is a list or vector of alists with headword, pos, and senses."
               (when idiom-text
                 (insert (propertize idiom-text 'face '(:inherit lexdb-phrase-face :weight bold))))
               (insert "\n")
-              ;; Second line: labels and definition
-              (insert "  ")
-              ;; Labels (fml, infml, etc.) before definition
-              (let ((idiom-labels (alist-get 'labels idiom)))
-                (when idiom-labels
-                  (let ((label-list (cond ((vectorp idiom-labels) (append idiom-labels nil))
-                                          ((listp idiom-labels) idiom-labels)
-                                          (t nil))))
-                    (dolist (label label-list)
-                      (let ((lvalue (alist-get 'value label)))
-                        (when lvalue
-                          (insert (propertize lvalue 'face 'lexdb-grammar-face) " ")))))))
-              ;; Definition - check for pre-parsed crossref first, then fallback to regex
-              (when (and idiom-def (stringp idiom-def) (not (string-empty-p idiom-def)))
-                (let ((crossref (alist-get 'crossref idiom)))
-                  (if crossref
-                      ;; Pre-parsed crossref from database (new format)
-                      (let* ((prefix (alist-get 'prefix crossref))
-                             (clickable (alist-get 'clickable crossref))
-                             (target-word (alist-get 'target_word crossref))
-                             (search-word (lexdb-ui--normalize-search-word
-                                           (or target-word clickable))))
-                        (when prefix
-                          (insert (propertize prefix 'face 'lexdb-crossref-face)))
-                        (insert-text-button clickable
-                                            'face 'lexdb-crossref-face
-                                            'action (lambda (_)
-                                                      (lexdb-search-and-goto-sense
-                                                       search-word nil jump-adapter))
-                                            'help-echo (format "Look up: %s [%s]"
-                                                               search-word jump-adapter)))
-                    ;; Fallback: regex detection for legacy data (→word.)
-                    (if (string-match "^→\\([^.]+\\)\\.$" idiom-def)
-                        (let* ((raw-target (match-string 1 idiom-def))
-                               (search-word (lexdb-ui--normalize-search-word raw-target)))
-                          (insert (propertize "→" 'face 'lexdb-crossref-face))
-                          (insert-text-button raw-target
-                                              'face 'lexdb-crossref-face
-                                              'action (lambda (_)
-                                                        (lexdb-search-and-goto-sense
-                                                         search-word nil jump-adapter))
-                                              'help-echo (format "Look up: %s [%s]" search-word jump-adapter)))
-                      ;; Regular definition with format markers
-                      (lexdb-ui--insert-formatted-definition idiom-def 'lexdb-definition-face)))))
-              (insert "\n")
+              ;; Second line: labels and definition (only if there's content)
+              (let* ((idiom-labels (alist-get 'labels idiom))
+                     (label-list (cond ((vectorp idiom-labels) (append idiom-labels nil))
+                                       ((listp idiom-labels) idiom-labels)
+                                       (t nil)))
+                     (has-valid-labels (and label-list
+                                            (cl-some (lambda (l) (alist-get 'value l)) label-list)))
+                     ;; Only show definition if it contains English letters
+                     (idiom-def-valid (and idiom-def (stringp idiom-def)
+                                           (not (string-empty-p idiom-def))
+                                           (string-match-p "[a-zA-Z]" idiom-def))))
+                (when (or has-valid-labels idiom-def-valid)
+                  (insert "  ")
+                  ;; Labels (fml, infml, etc.) before definition
+                  (dolist (label label-list)
+                    (let ((lvalue (alist-get 'value label)))
+                      (when lvalue
+                        (insert (propertize lvalue 'face 'lexdb-grammar-face) " "))))
+                  ;; Definition - check for pre-parsed crossref first, then fallback to regex
+                  (when idiom-def-valid
+                    (let ((crossref (alist-get 'crossref idiom)))
+                      (if crossref
+                          ;; Pre-parsed crossref from database (new format)
+                          (let* ((prefix (alist-get 'prefix crossref))
+                                 (clickable (alist-get 'clickable crossref))
+                                 (target-word (alist-get 'target_word crossref))
+                                 (search-word (lexdb-ui--normalize-search-word
+                                               (or target-word clickable))))
+                            (when prefix
+                              (insert (propertize prefix 'face 'lexdb-crossref-face)))
+                            (insert-text-button clickable
+                                                'face 'lexdb-crossref-face
+                                                'action (lambda (_)
+                                                          (lexdb-search-and-goto-sense
+                                                           search-word nil jump-adapter))
+                                                'help-echo (format "Look up: %s [%s]"
+                                                                   search-word jump-adapter)))
+                        ;; Fallback: regex detection for legacy data (→word.)
+                        (if (string-match "^→\\([^.]+\\)\\.$" idiom-def)
+                            (let* ((raw-target (match-string 1 idiom-def))
+                                   (search-word (lexdb-ui--normalize-search-word raw-target)))
+                              (insert (propertize "→" 'face 'lexdb-crossref-face))
+                              (insert-text-button raw-target
+                                                  'face 'lexdb-crossref-face
+                                                  'action (lambda (_)
+                                                            (lexdb-search-and-goto-sense
+                                                             search-word nil jump-adapter))
+                                                  'help-echo (format "Look up: %s [%s]" search-word jump-adapter)))
+                          ;; Regular definition with format markers
+                          (lexdb-ui--insert-formatted-definition idiom-def 'lexdb-definition-face)))))
+                  (insert "\n")))
               (when idiom-examples
                 (let ((ex-list (cond ((vectorp idiom-examples) (append idiom-examples nil))
                                      ((listp idiom-examples) idiom-examples)
@@ -2484,6 +2492,26 @@ PHRASAL-VERBS is a list or vector of alists with headword, pos, and senses."
 (defun lexdb-ui--slot-synonyms (entry adapter)
   "Slot: Render synonyms and cross-references."
   (lexdb-ui--render-synonyms-and-crossrefs entry adapter))
+
+(defun lexdb-ui--slot-runons (entry adapter)
+  "Slot: Render run-on entries (derived words like 'relevantly adverb')."
+  (let* ((ns (symbol-name (lexdb-adapter-id adapter)))
+         (runons (lexdb-meta-get (lexdb-entry-metadata entry) ns "runons")))
+    (when (and runons (> (length runons) 0))
+      (let ((runon-list (cond ((vectorp runons) (append runons nil))
+                              ((listp runons) runons)
+                              (t nil))))
+        (when runon-list
+          (insert "\n")
+          (dolist (runon runon-list)
+            (let ((word (cdr (assoc 'word runon)))
+                  (pos (cdr (assoc 'pos runon))))
+              (when word
+                (insert (propertize "—" 'face 'lexdb-label-face))
+                (insert (propertize word 'face 'lexdb-headword-face))
+                (when (and pos (not (string-empty-p pos)))
+                  (insert " " (propertize pos 'face 'lexdb-pos-face)))
+                (insert "\n")))))))))
 
 (defun lexdb-ui--slot-separator (_entry _adapter)
   "Slot: Render entry separator line."

--- a/scripts/mdx2db.py
+++ b/scripts/mdx2db.py
@@ -136,7 +136,13 @@ class LDOCEParser:
         soup = BeautifulSoup(html, HTML_PARSER)
 
         # Find all entry divs (for homographs like swing1, swing2)
-        entry_divs = soup.find_all(class_='entry')
+        # Exclude entries inside popups (at-link) - they are nested entries for Word Origin, Examples, etc.
+        entry_divs = []
+        for entry_elem in soup.find_all(class_='entry'):
+            # Skip if inside a popup (at-link)
+            if entry_elem.find_parent(class_='at-link'):
+                continue
+            entry_divs.append(entry_elem)
 
         # If no entry divs found, treat whole HTML as single entry
         if not entry_divs:
@@ -1361,6 +1367,25 @@ class LDOCEParser:
                 if ref_text and ref_link and ref_text not in cross_refs_dict:
                     cross_refs_dict[ref_text] = ref_link
 
+            # Extract run-on entries (derived words like "—relevantly adverb")
+            runons = []
+            for runon in tail.find_all(class_='runon'):
+                deriv = runon.find(class_='deriv')
+                pos = runon.find(class_='pos')
+                if deriv:
+                    deriv_text = clean_text(deriv.get_text())
+                    # Remove leading dash if present
+                    if deriv_text.startswith('—') or deriv_text.startswith('-'):
+                        deriv_text = deriv_text[1:].strip()
+                    pos_text = clean_text(pos.get_text()) if pos else ''
+                    if deriv_text:
+                        runons.append({
+                            'word': deriv_text,
+                            'pos': pos_text
+                        })
+            if runons:
+                entry['attributes']['runons'] = runons
+
         # Parse crossref sections - handle reflex + link combinations
         # Now using fragment storage for cleaner rendering
         for crossref in soup.find_all(class_='crossref'):
@@ -2349,6 +2374,12 @@ def convert_mdx_to_lexdb(mdx_file, db_path=None, extract_audio=False, dict_type=
 
             for entry_data in entries:
                 if entry_data.get('senses'):
+                    # Skip redirects: if parsed headword differs from MDX key, it's a redirect
+                    parsed_hw = entry_data.get('headword', '').lower().rstrip('0123456789')
+                    word_key_lower = word_key.lower()
+                    if parsed_hw and parsed_hw != word_key_lower:
+                        # This is likely a redirect (e.g., "relevantly" -> "relevant")
+                        continue
                     writer.write_entry(entry_data)
                     success += 1
         except Exception as e:


### PR DESCRIPTION
- Skip idiom definition line when it contains no English letters
- Display lexunit prefix before grammar label (e.g., "particulars [plural]")
- Extract and display derived words from tail section (e.g., "—relevantly adverb")
- Fix duplicate entries caused by popup entries with class="entry"
- Skip redirect entries where parsed headword differs from MDX key
- Add __pycache__ to .gitignore