### PR TITLE
fix: render part of speech refs in idiom crossrefs with correct face

### DIFF
--- a/lexdb-ui.el
+++ b/lexdb-ui.el
@@ -2582,6 +2582,7 @@ IDIOM is the full idiom alist, ADAPTER-ID for crossref jumps."
      (crossref
       (let* ((prefix (alist-get 'prefix crossref))
              (clickable (alist-get 'clickable crossref))
+             (suffix (alist-get 'suffix crossref))
              (target-word (alist-get 'target_word crossref))
              (search-word (lexdb-ui--normalize-search-word
                            (or target-word clickable))))
@@ -2593,7 +2594,11 @@ IDIOM is the full idiom alist, ADAPTER-ID for crossref jumps."
                                       (lexdb-search-and-goto-sense
                                        search-word nil adapter-id))
                             'help-echo (format "Look up: %s [%s]"
-                                               search-word adapter-id))))
+                                               search-word adapter-id))
+        ;; Render suffix with format markers (e.g., <<pos>>v<</pos>>)
+        (when suffix
+          (insert " ")
+          (lexdb-ui--insert-formatted-definition suffix 'lexdb-crossref-face))))
      ;; Arrow-style crossref in definition
      ((string-match "^→\\([^.]+\\)\\.$" idiom-def)
       (let* ((raw-target (match-string 1 idiom-def))

--- a/scripts/mdx2db_oald.py
+++ b/scripts/mdx2db_oald.py
@@ -199,7 +199,7 @@ def extract_highlighted_example(element):
 
 
 def parse_cross_reference(text):
-    """Parse cross-reference text like '→necessity.' or '→old.'
+    """Parse cross-reference text like '→necessity.' or '→coin <<pos>>v<</pos>>.'
 
     Returns:
         dict with 'is_crossref', 'prefix', 'clickable', 'suffix', 'target_word', 'target_sense'
@@ -208,16 +208,25 @@ def parse_cross_reference(text):
     if not text:
         return None
 
-    # Pattern: →word. or → word.
+    # Pattern: →word. or → word. (may include format markers like <<pos>>v<</pos>>)
     match = re.match(r'^→\s*([^.]+)\.$', text.strip())
     if match:
         target = match.group(1).strip()
+        # Separate clickable word from suffix (e.g., "coin <<pos>>v<</pos>>" -> "coin", "<<pos>>v<</pos>>")
+        # Look for format markers or trailing text after the main word
+        suffix_match = re.match(r'^(\S+)((?:\s+<<\w+>>.+)?)\s*$', target)
+        if suffix_match:
+            clickable = suffix_match.group(1)
+            suffix = suffix_match.group(2).strip() if suffix_match.group(2) else None
+        else:
+            clickable = target
+            suffix = None
         return {
             'is_crossref': True,
             'prefix': '→',
-            'clickable': target,
-            'suffix': None,
-            'target_word': target.lower(),
+            'clickable': clickable,
+            'suffix': suffix,
+            'target_word': clickable.lower(),
             'target_sense': None  # OALD4 doesn't have sense-level cross-refs
         }
     return None


### PR DESCRIPTION
In idiom cross-references like "→coin v.", the part of speech indicator ("v") was being rendered as part of the clickable link instead of using the proper lexdb-pos-face styling. This fix:

1. Updates parse_cross_reference() to separate the clickable word from any format markers (<<pos>>v<</pos>>) into a separate 'suffix' field
2. Updates lexdb-ui--render-idiom-definition to render the suffix using lexdb-ui--insert-formatted-definition, which applies the correct face