### PR TITLE
refactor: reduce nested let/if structures for better readability

### DIFF
--- a/lexdb-ldoce.el
+++ b/lexdb-ldoce.el
@@ -74,19 +74,25 @@
 ;;;; Schema V2 (New LexDB Schema)
 ;;;; ============================================================
 
+(defun lexdb-ldoce--build-example (ex &optional include-position)
+  "Build lexdb-example from row EX.
+If INCLUDE-POSITION is non-nil, include position in metadata."
+  (let ((text (nth 0 ex))
+        (audio (nth 1 ex))
+        (position (nth 2 ex)))
+    (lexdb-example-create
+     :text text
+     :audio (when (lexdb--non-empty-string-p audio) audio)
+     :metadata (when include-position
+                 (list (cons 'position position))))))
+
 (defun lexdb-ldoce--v2-row-to-sense (sense-row db)
   "Convert V2 SENSE-ROW to lexdb-sense."
   (pcase-let ((`(,id ,sense-num ,signpost ,definition ,_sort) sense-row))
     (let* ((ex-rows (sqlite-select db
                      "SELECT text, audio_path, position FROM examples WHERE sense_id = ? ORDER BY position, sort_order"
                      (list id)))
-           (examples (mapcar (lambda (ex)
-                               (lexdb-example-create
-                                :text (nth 0 ex)
-                                :audio (let ((p (nth 1 ex)))
-                                         (when (lexdb--non-empty-string-p p) p))
-                                :metadata (list (cons 'position (nth 2 ex)))))
-                             ex-rows))
+           (examples (mapcar (lambda (ex) (lexdb-ldoce--build-example ex t)) ex-rows))
            (label-rows (sqlite-select db
                         "SELECT label_type, label_value FROM labels WHERE sense_id = ? ORDER BY sort_order"
                         (list id)))
@@ -117,13 +123,8 @@
                                 (list pat-id))))
                   (lexdb-grammar-pattern-create
                    :pattern pattern
-                   :gloss (when (and gloss (not (string-empty-p gloss))) gloss)
-                   :examples (mapcar (lambda (ex)
-                                       (lexdb-example-create
-                                        :text (nth 0 ex)
-                                        :audio (let ((p (nth 1 ex)))
-                                                 (when (lexdb--non-empty-string-p p) p))))
-                                     ex-rows)))))
+                   :gloss (when (lexdb--non-empty-string-p gloss) gloss)
+                   :examples (mapcar #'lexdb-ldoce--build-example ex-rows)))))
             rows)))
 
 (defalias 'lexdb-ldoce--v2-build-pronunciations #'lexdb--build-pronunciations-from-db

--- a/lexdb-oald.el
+++ b/lexdb-oald.el
@@ -72,51 +72,48 @@
 ;;;; Schema Queries
 ;;;; ============================================================
 
+(defun lexdb-oald--build-example (ex)
+  "Build lexdb-example from row EX with optional Chinese translation."
+  (pcase-let ((`(,text ,text-zh) ex))
+    (lexdb-example-create
+     :text text
+     :metadata (when (and lexdb-oald-show-chinese
+                          (lexdb--non-empty-string-p text-zh))
+                 (list (cons 'oald/text-zh text-zh))))))
+
+(defun lexdb-oald--build-sense-metadata (definition-zh plural)
+  "Build sense metadata from DEFINITION-ZH and PLURAL."
+  (let ((meta nil))
+    (when (and lexdb-oald-show-chinese
+               (lexdb--non-empty-string-p definition-zh))
+      (push (cons 'oald/definition-zh definition-zh) meta))
+    (when (lexdb--non-empty-string-p plural)
+      (push (cons 'oald/plural plural) meta))
+    meta))
+
 (defun lexdb-oald--row-to-sense (sense-row db)
   "Convert SENSE-ROW to lexdb-sense using DB connection."
   (pcase-let ((`(,id ,sense-num ,signpost ,plural ,definition ,definition-zh ,_sort) sense-row))
     (let* ((ex-rows (sqlite-select db
                      "SELECT text, text_zh FROM examples WHERE sense_id = ? ORDER BY sort_order"
                      (list id)))
-           (examples (mapcar (lambda (ex)
-                               (let ((text (nth 0 ex))
-                                     (text-zh (nth 1 ex)))
-                                 (lexdb-example-create
-                                  :text text
-                                  ;; Store Chinese in metadata
-                                  :metadata (when (and lexdb-oald-show-chinese
-                                                       (lexdb--non-empty-string-p text-zh))
-                                              (list (cons 'oald/text-zh text-zh))))))
-                             ex-rows))
            (gram-rows (sqlite-select db
                        "SELECT pattern FROM grammar_patterns WHERE sense_id = ? ORDER BY sort_order"
                        (list id)))
-           (gram-patterns (mapcar (lambda (g)
-                                    (lexdb-grammar-pattern-create :pattern (car g)))
-                                  gram-rows))
            (label-rows (sqlite-select db
                         "SELECT label_type, label_value FROM labels WHERE sense_id = ? ORDER BY sort_order"
-                        (list id)))
-           (labels (mapcar (lambda (l)
-                             (lexdb-label-create :type (intern (nth 0 l)) :value (nth 1 l)))
-                           label-rows)))
-      (let ((meta nil))
-        ;; Store Chinese definition in metadata
-        (when (and lexdb-oald-show-chinese
-                   (lexdb--non-empty-string-p definition-zh))
-          (push (cons 'oald/definition-zh definition-zh) meta))
-        ;; Store plural forms in metadata
-        (when (lexdb--non-empty-string-p plural)
-          (push (cons 'oald/plural plural) meta))
-        (lexdb-sense-create
-         :id id
-         :number (when (lexdb--non-empty-string-p sense-num) sense-num)
-         :signpost (when (lexdb--non-empty-string-p signpost) signpost)
-         :definition definition
-         :examples examples
-         :grammar-patterns gram-patterns
-         :labels labels
-         :metadata meta)))))
+                        (list id))))
+      (lexdb-sense-create
+       :id id
+       :number (when (lexdb--non-empty-string-p sense-num) sense-num)
+       :signpost (when (lexdb--non-empty-string-p signpost) signpost)
+       :definition definition
+       :examples (mapcar #'lexdb-oald--build-example ex-rows)
+       :grammar-patterns (mapcar (lambda (g) (lexdb-grammar-pattern-create :pattern (car g)))
+                                 gram-rows)
+       :labels (mapcar (lambda (l) (lexdb-label-create :type (intern (nth 0 l)) :value (nth 1 l)))
+                       label-rows)
+       :metadata (lexdb-oald--build-sense-metadata definition-zh plural)))))
 
 (defalias 'lexdb-oald--build-pronunciations #'lexdb--build-pronunciations-from-db
   "Build pronunciations for ENTRY-ID from DB.")
@@ -144,20 +141,19 @@
           (when (and (equal ltype "pos") (not (assq 'oald/pos metadata)))
             (push (cons 'oald/pos lvalue) metadata))))
       ;; Fetch entry attributes (idioms, derivatives, subsenses, etc.)
-      (let ((attr-rows (sqlite-select db
-                        "SELECT attr_key, attr_value, attr_type FROM entry_attributes WHERE entry_id = ?"
-                        (list id))))
-        (dolist (attr attr-rows)
-          (pcase-let ((`(,key ,value ,type) attr))
-            (when (lexdb--non-empty-string-p value)
-              (let ((parsed-value (if (equal type "json_compressed")
-                                      (lexdb-oald--decompress-json value)
-                                    value)))
-                ;; Extract subsenses map for sense-level distribution
-                ;; Note: Database has "oald/oald/subsenses" due to dict_id prefix in storage
-                (if (equal key "oald/oald/subsenses")
-                    (setq subsenses-map parsed-value)
-                  (push (cons (intern key) parsed-value) metadata)))))))
+      (dolist (attr (sqlite-select db
+                      "SELECT attr_key, attr_value, attr_type FROM entry_attributes WHERE entry_id = ?"
+                      (list id)))
+        (pcase-let ((`(,key ,value ,type) attr))
+          (when-let* ((parsed-value (and (lexdb--non-empty-string-p value)
+                                         (if (equal type "json_compressed")
+                                             (lexdb-oald--decompress-json value)
+                                           value))))
+            ;; Extract subsenses map for sense-level distribution
+            ;; Note: Database has "oald/oald/subsenses" due to dict_id prefix in storage
+            (if (equal key "oald/oald/subsenses")
+                (setq subsenses-map parsed-value)
+              (push (cons (intern key) parsed-value) metadata)))))
       ;; Convert sense rows, attaching subsenses from map
       (let ((senses (mapcar (lambda (sr)
                               (let* ((sense (lexdb-oald--row-to-sense sr db))

--- a/lexdb-ui.el
+++ b/lexdb-ui.el
@@ -112,24 +112,25 @@ Returns adapter-specific template or default template."
   (or lexdb-enabled-adapters
       (mapcar #'car (lexdb-list-adapters))))
 
+(defun lexdb-ui--lookup-with-lemma (word adapter-id adapter)
+  "Lookup WORD in ADAPTER-ID, trying lemmatization if no results.
+ADAPTER is the adapter struct.  Returns entries list or nil."
+  (or (condition-case nil (lexdb-lookup word adapter-id) (error nil))
+      (when (lexdb-adapter-has-capability-p adapter 'lemmatization)
+        (when-let* ((lemma (lexdb-find-lemma word adapter-id))
+                    ((not (equal lemma (downcase word)))))
+          (condition-case nil (lexdb-lookup lemma adapter-id) (error nil))))))
+
 (defun lexdb-ui--query-all-dicts (word)
   "Query WORD in all enabled dictionaries.
 Returns alist of (adapter-id . (entries . adapter))."
   (let ((results nil))
     (dolist (adapter-id (lexdb-ui--get-enabled-adapters))
       (when-let* ((adapter (lexdb-get-adapter adapter-id)))
-        (let ((entries (condition-case nil
-                           (lexdb-lookup word adapter-id)
-                         (error nil))))
-          ;; Try lemmatization if no results
-          (unless entries
-            (when (lexdb-adapter-has-capability-p adapter 'lemmatization)
-              (when-let* ((lemma (lexdb-find-lemma word adapter-id)))
-                (unless (equal lemma (downcase word))
-                  (setq entries (condition-case nil
-                                    (lexdb-lookup lemma adapter-id)
-                                  (error nil)))))))
-          (push (cons adapter-id (cons entries adapter)) results))))
+        (push (cons adapter-id
+                    (cons (lexdb-ui--lookup-with-lemma word adapter-id adapter)
+                          adapter))
+              results)))
     (nreverse results)))
 
 (defun lexdb-ui--render-dict-tabs ()

--- a/lexdb.el
+++ b/lexdb.el
@@ -952,20 +952,13 @@ Otherwise, search only the current/default dictionary."
       (princ (format "Version: %s\n\n" (or (lexdb-adapter-version adapter) "unknown")))
       (princ "Capabilities:\n\n")
       (dolist (group lexdb-capability-groups)
-        (let ((group-name (car group))
-              (group-caps (cdr group))
-              (has-any nil))
-          ;; Check if this group has any enabled caps
-          (dolist (cap-pair group-caps)
-            (when (memq (car cap-pair) caps)
-              (setq has-any t)))
-          (when has-any
+        (let* ((group-name (car group))
+               (enabled-caps (seq-filter (lambda (cap-pair) (memq (car cap-pair) caps))
+                                         (cdr group))))
+          (when enabled-caps
             (princ (format "  %s:\n" (upcase (symbol-name group-name))))
-            (dolist (cap-pair group-caps)
-              (let ((cap (car cap-pair))
-                    (desc (cdr cap-pair)))
-                (when (memq cap caps)
-                  (princ (format "    ✓ %s - %s\n" cap desc)))))
+            (dolist (cap-pair enabled-caps)
+              (princ (format "    ✓ %s - %s\n" (car cap-pair) (cdr cap-pair))))
             (princ "\n")))))))
 
 ;;;###autoload
@@ -1011,14 +1004,13 @@ VARIANT can be \\='uk or \\='us (default: \\='uk)."
          (variant (or variant 'uk)))
     (if (null entries)
         (message "No entry found for: %s" lexdb--last-word)
-      (let* ((entry (car entries))
-             (prons (lexdb-entry-pronunciations entry))
-             (pron (seq-find (lambda (p) (eq (lexdb-pronunciation-variant p) variant))
-                             prons)))
-        (if (and pron (lexdb-pronunciation-audio pron))
-            (lexdb-ui--play-audio (lexdb-pronunciation-audio pron)
-                                  (lexdb-adapter-audio-dir adapter))
-          (message "No %s audio for: %s" variant lexdb--last-word))))))
+      (if-let* ((entry (car entries))
+                (prons (lexdb-entry-pronunciations entry))
+                (pron (seq-find (lambda (p) (eq (lexdb-pronunciation-variant p) variant))
+                                prons))
+                (audio (lexdb-pronunciation-audio pron)))
+          (lexdb-ui--play-audio audio (lexdb-adapter-audio-dir adapter))
+        (message "No %s audio for: %s" variant lexdb--last-word)))))
 
 ;;;###autoload
 (defun lexdb-play-uk ()


### PR DESCRIPTION
- Extract helper functions to reduce nesting depth:
  - lexdb-ldoce--build-example: build example from row
  - lexdb-oald--build-example: build example with Chinese translation
  - lexdb-oald--build-sense-metadata: build sense metadata
  - lexdb-ui--lookup-with-lemma: lookup with lemmatization fallback
- Use if-let*/when-let* to replace nested let + when/if patterns
- Use seq-filter to simplify capability rendering loop
- Reduce max nesting from 7 levels to 3-4 levels